### PR TITLE
CPIT-631 Small bugs and improvements

### DIFF
--- a/src/app/Tool/carbon-market/carbon-market-assessment/carbon-market-assessment.component.html
+++ b/src/app/Tool/carbon-market/carbon-market-assessment/carbon-market-assessment.component.html
@@ -466,6 +466,11 @@
             </div>
             <div class="row justify-content-end" *ngIf="!isSavedAssessment || (isEditMode && isCompleted && isContinue)">
                 <div class="row p-grid p-fluid col-md-6 col-sm-6">
+                    <div class="d-flex col-4 justify-content-end p-button-vertical mb-0 pl-2" *ngIf="!isSavedAssessment && !isEditMode">
+                        <button class="btn btn-outline-primary" type="button" (click)="saveDraft()">
+                            Save as Draft
+                        </button>
+                    </div>
                     <div class="d-flex col-4 justify-content-end p-button-vertical mb-0 pl-2">
                         <button class="btn btn-primary" type="submit">
                             {{isCompleted ? 'Update' : (!isContinue ? 'Update' : 'Submit')}}

--- a/src/app/Tool/carbon-market/carbon-market-assessment/carbon-market-assessment.component.ts
+++ b/src/app/Tool/carbon-market/carbon-market-assessment/carbon-market-assessment.component.ts
@@ -306,13 +306,13 @@ logOutSubs: Subscription;
               req.boundraries = this.cm_detail.boundraries;
               req.intCMApproach = this.cm_detail.intCMApproach;
               req.appliedMethodology = this.cm_detail.appliedMethodology;
-              //@ts-ignore
-              req.sectorsCovered = undefined
-              //@ts-ignore
-              req.geographicalAreasCovered = undefined
+              delete (req as any).sectorsCovered;
+              delete (req as any).geographicalAreasCovered;
 
             } else {
               req = this.cm_detail;
+              delete (req as any).sectorsCovered;
+              delete (req as any).geographicalAreasCovered;
             }
 
             this.serviceProxy.createOneBaseAssessmentCMDetailControllerAssessmentCMDetail(req)
@@ -397,9 +397,46 @@ logOutSubs: Subscription;
     }
   }
 
+  saveDraft() {
+    this.assessment.tool = 'CARBON_MARKET'
+    this.assessment.assessment_approach = 'DIRECT'
+    this.assessment.isDraft = true
+    this.assessment.lastDraftLocation = 'initial'
+    if (!this.assessment.id) this.assessment.createdOn = moment(new Date())
+    this.assessment.editedOn = moment(new Date())
+    if (this.from_date) this.assessment.from = moment(this.from_date)
+    if (this.to_date) this.assessment.to = moment(this.to_date)
+
+    this.methodologyAssessmentControllerServiceProxy.saveAssessment(this.assessment)
+      .subscribe(res => {
+        if (res) {
+          this.assessment = res
+          this.assessmentres = res
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Success',
+            detail: 'Assessment saved as draft',
+            closable: true,
+          })
+        }
+      }, error => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Draft save failed',
+          closable: true,
+        })
+      })
+  }
+
   onSelectIntervention(event: any) {
     this.minDate = new Date(event.value.dateOfImplementation)
     
+    if (!this.isEditMode) {
+      this.from_date = new Date(event.value.dateOfImplementation);
+      this.onSelectFromDate(this.from_date);
+    }
+
     this.geographicalArea = this.geographicalAreasCovered.find(item=>{
       if (item.name==this.assessment.climateAction.geographicalAreaCovered){
         return item

--- a/src/app/Tool/carbon-market/cm-question/cm-question.component.html
+++ b/src/app/Tool/carbon-market/cm-question/cm-question.component.html
@@ -45,7 +45,7 @@
     </div>
     <div class="col-2">
         <p-fileUpload [disabled]="!selectedAnswer" mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" 
-        (onUpload)="onUpload($event,'FILE')" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" 
+        (onUpload)="onUpload($event,'FILE')" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" 
         [auto]="true">
         </p-fileUpload>
     </div>

--- a/src/app/Tool/carbon-market/cm-section-three/cm-section-three.component.html
+++ b/src/app/Tool/carbon-market/cm-section-three/cm-section-three.component.html
@@ -167,7 +167,7 @@
                                         </p>
                                     </div>
                                     <div class="col-2">
-                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.name, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.name, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                         </p-fileUpload>
                                     </div>
                                 </div>
@@ -217,7 +217,7 @@
                                         </p>
                                     </div>
                                     <div class="col-2">
-                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                         </p-fileUpload>
                                     </div>
                                 </div>
@@ -369,7 +369,7 @@
                                         </p>
                                     </div>
                                     <div class="col-2">
-                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                         </p-fileUpload>
                                     </div>
                                 </div>
@@ -419,7 +419,7 @@
                                         </p>
                                     </div>
                                     <div class="col-2">
-                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                        <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char);autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, undefined)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                         </p-fileUpload>
                                     </div>
                                 </div>
@@ -567,7 +567,7 @@
                                                     </p>
                                                 </div>
                                                 <div class="col-2">
-                                                    <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char); autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, SDG.id)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                                    <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,char); autoSaveResult(category.code, true, category.code, 'out', char.characteristic.id, undefined, SDG.id)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                                     </p-fileUpload>
                                                 </div>
                                             </div>
@@ -620,7 +620,7 @@
                                                     </p>
                                                 </div>
                                                 <div class="col-2">
-                                                    <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,chSus);autoSaveResult(category.code, true, category.code, 'out', chSus.characteristic.id, undefined, SDG.id)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                                    <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,chSus);autoSaveResult(category.code, true, category.code, 'out', chSus.characteristic.id, undefined, SDG.id)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                                     </p-fileUpload>
                                                 </div>
                                             </div>

--- a/src/app/Tool/carbon/carbon.component.html
+++ b/src/app/Tool/carbon/carbon.component.html
@@ -298,7 +298,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"></p-fileUpload>
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"></p-fileUpload>
                             <br> <br>
                           </div>
 
@@ -358,7 +358,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000"
+                              [multiple]="true" [maxFileSize]="25000000"
                               styleClass="custom-file-upload"></p-fileUpload><br> <br>
 
 
@@ -407,7 +407,7 @@
                           <p-fileUpload name="file" [customUpload]="true"
                             (uploadHandler)="myUploader($event,category.name)"
                             url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                            [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"></p-fileUpload>
+                            [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"></p-fileUpload>
                           <br> <br>
 
 
@@ -441,7 +441,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"></p-fileUpload>
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"></p-fileUpload>
                             <br> <br>
 
                           </div>
@@ -487,7 +487,7 @@
                           <p-fileUpload name="file" [customUpload]="true"
                             (uploadHandler)="myUploader($event,category.name)"
                             url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                            [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"></p-fileUpload>
+                            [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"></p-fileUpload>
                           <br> <br>
 
                           <label for="characteristics">
@@ -520,7 +520,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000"
+                              [multiple]="true" [maxFileSize]="25000000"
                               styleClass="custom-file-upload"></p-fileUpload><br> <br>
 
 
@@ -600,7 +600,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"
                               [disabled]="isSubmitted"></p-fileUpload>
                             <br> <br>
                           </div>
@@ -667,7 +667,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"
                               [disabled]="isSubmitted"></p-fileUpload><br> <br>
 
 
@@ -725,7 +725,7 @@
                           <p-fileUpload name="file" [customUpload]="true"
                             (uploadHandler)="myUploader($event,category.name)"
                             url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                            [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"
+                            [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"
                             [disabled]="isSubmitted"></p-fileUpload>
                           <br> <br>
 
@@ -768,7 +768,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"
                               [disabled]="isSubmitted"></p-fileUpload>
                             <br> <br>
 
@@ -823,7 +823,7 @@
                           <p-fileUpload name="file" [customUpload]="true"
                             (uploadHandler)="myUploader($event,category.name)"
                             url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                            [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"
+                            [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"
                             [disabled]="isSubmitted"></p-fileUpload>
                           <br> <br>
 
@@ -865,7 +865,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"
                               [disabled]="isSubmitted"></p-fileUpload><br> <br>
 
 
@@ -950,7 +950,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"></p-fileUpload>
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"></p-fileUpload>
                             <br> <br>
                           </div>
 
@@ -1022,7 +1022,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000"
+                              [multiple]="true" [maxFileSize]="25000000"
                               styleClass="custom-file-upload"></p-fileUpload><br> <br>
 
 
@@ -1113,7 +1113,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000" styleClass="custom-file-upload"></p-fileUpload>
+                              [multiple]="true" [maxFileSize]="25000000" styleClass="custom-file-upload"></p-fileUpload>
                             <br> <br>
 
                           </div>
@@ -1201,7 +1201,7 @@
                             <p-fileUpload name="file" [customUpload]="true"
                               (uploadHandler)="myUploader($event,characteristic.name)"
                               url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                              [multiple]="true" [maxFileSize]="5000000"
+                              [multiple]="true" [maxFileSize]="25000000"
                               styleClass="custom-file-upload"></p-fileUpload><br> <br>
 
                           </div>
@@ -1451,7 +1451,7 @@
 
                     <p-fileUpload name="file" [customUpload]="true" (uploadHandler)="myUploader($event,category.name)"
                       url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="5000000"
+                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="25000000"
                       styleClass="custom-file-upload" class="narrow-file-upload"
                       [showUploadButton]="!categoryFileUploaded[category.name]"></p-fileUpload>
 
@@ -1509,7 +1509,7 @@
                       <p-fileUpload name="file" [customUpload]="true"
                         (uploadHandler)="myUploader($event,characteristic.name)"
                         url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="5000000"
+                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="25000000"
                         styleClass="custom-file-upload" class="narrow-file-upload"
                         [showUploadButton]="!categoryFileUploaded[characteristic.name]"></p-fileUpload>
 
@@ -1574,7 +1574,7 @@
                     <label class="mr-4">Upload Document : </label>
                     <p-fileUpload name="file" [customUpload]="true" (uploadHandler)="myUploader($event,category.name)"
                       url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="5000000"
+                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="25000000"
                       styleClass="custom-file-upload" class="narrow-file-upload"
                       [showUploadButton]="!categoryFileUploaded[category.name]"></p-fileUpload>
                     <br> <br>
@@ -1634,7 +1634,7 @@
                       <p-fileUpload name="file" [customUpload]="true"
                         (uploadHandler)="myUploader($event,characteristic.name)"
                         url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="5000000"
+                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="25000000"
                         styleClass="custom-file-upload" class="narrow-file-upload"
                         [showUploadButton]="!categoryFileUploaded[characteristic.name]"></p-fileUpload>
                       <br> <br>
@@ -1747,7 +1747,7 @@
 
                     <p-fileUpload name="file" [customUpload]="true" (uploadHandler)="myUploader($event,category.name)"
                       url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="5000000"
+                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="25000000"
                       styleClass="custom-file-upload" class="narrow-file-upload"
                       [showUploadButton]="!categoryFileUploaded[category.name]"></p-fileUpload>
 
@@ -1806,7 +1806,7 @@
                       <p-fileUpload name="file" [customUpload]="true"
                         (uploadHandler)="myUploader($event,characteristic.name)"
                         url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="5000000"
+                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="25000000"
                         styleClass="custom-file-upload" class="narrow-file-upload"
                         [showUploadButton]="!categoryFileUploaded[characteristic.name]"></p-fileUpload>
                       <br> <br>
@@ -1870,7 +1870,7 @@
                     <label class="mr-4">Upload Document : </label>
                     <p-fileUpload name="file" [customUpload]="true" (uploadHandler)="myUploader($event,category.name)"
                       url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="5000000"
+                      [multiple]="true" [disabled]="categoryFileUploaded[category.name]" [maxFileSize]="25000000"
                       styleClass="custom-file-upload" class="narrow-file-upload"
                       [showUploadButton]="!categoryFileUploaded[category.name]"></p-fileUpload>
                     <br> <br>
@@ -1927,7 +1927,7 @@
                       <p-fileUpload name="file" [customUpload]="true"
                         (uploadHandler)="myUploader($event,characteristic.name)"
                         url="{{ baseURL }}/methodology-assessment/uploadtest" (onUpload)="onUpload($event)"
-                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="5000000"
+                        [multiple]="true" [disabled]="categoryFileUploaded[characteristic.name]" [maxFileSize]="25000000"
                         styleClass="custom-file-upload" class="narrow-file-upload"
                         [showUploadButton]="!categoryFileUploaded[characteristic.name]"></p-fileUpload>
                       <br> <br>

--- a/src/app/Tool/investor-tool/investor-tool.component.html
+++ b/src/app/Tool/investor-tool/investor-tool.component.html
@@ -501,7 +501,7 @@
                             </div>
                             <div class="row p-2 align-items-center">
                               <div class="col-2 d-flex align-items-center">
-                                <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                 </p-fileUpload>
                               </div>
                               <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">
@@ -618,7 +618,7 @@
                               </div>
                               <div class="row p-2 align-items-center">
                                 <div class="col-2 d-flex align-items-center">
-                                  <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                  <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                   </p-fileUpload>
                                 </div>
                                 <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">
@@ -729,7 +729,7 @@
                                   </div>
                                   <div class="row p-2 align-items-center">
                                     <div class="col-2 d-flex align-items-center">
-                                      <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                      <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                       </p-fileUpload>
                                     </div>
                                     <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">
@@ -796,7 +796,7 @@
                                   </div>
                                   <div class="row p-2 align-items-center">
                                     <div class="col-2 d-flex align-items-center">
-                                      <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                      <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                       </p-fileUpload>
                                     </div>
                                     <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">

--- a/src/app/Tool/investor-tool/investor-tool.component.ts
+++ b/src/app/Tool/investor-tool/investor-tool.component.ts
@@ -870,6 +870,12 @@ export class InvestorToolComponent implements OnInit, AfterContentChecked, OnDes
 
   onSelectIntervention(event: any) {
     this.minDate = new Date(event.value.dateOfImplementation)
+
+    if (!this.isEditMode) {
+      this.from_date = new Date(event.value.dateOfImplementation);
+      this.onSelectFromDate(this.from_date);
+    }
+
     this.geographicalArea = this.geographicalAreasCovered.find(item=>{
       if (item.name==this.assessment.climateAction.geographicalAreaCovered){
         return item

--- a/src/app/Tool/investor/investor.component.html
+++ b/src/app/Tool/investor/investor.component.html
@@ -183,7 +183,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -246,7 +246,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 
@@ -300,7 +300,7 @@
               url="{{ baseURL }}/methodology-assessment/uploadtest"
               (onUpload)="onUpload($event)"
               [multiple]="true"
-              [maxFileSize]="5000000"
+              [maxFileSize]="25000000"
               styleClass="custom-file-upload"
             ></p-fileUpload>
             <br>  <br>
@@ -337,7 +337,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -389,7 +389,7 @@
               url="{{ baseURL }}/methodology-assessment/uploadtest"
               (onUpload)="onUpload($event)"
               [multiple]="true"
-              [maxFileSize]="5000000"
+              [maxFileSize]="25000000"
               styleClass="custom-file-upload"
             ></p-fileUpload>
             <br>  <br>
@@ -425,7 +425,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 
@@ -505,7 +505,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -572,7 +572,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload><br>  <br>
@@ -634,7 +634,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -677,7 +677,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -737,7 +737,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -779,7 +779,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload><br>  <br>
@@ -855,7 +855,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -918,7 +918,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 
@@ -990,7 +990,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -1060,7 +1060,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 
@@ -1223,7 +1223,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -1264,7 +1264,7 @@
                       url="{{ baseURL }}/methodology-assessment/uploadtest"
                       (onUpload)="onUpload($event)"
                       [multiple]="true"
-                      [maxFileSize]="5000000"
+                      [maxFileSize]="25000000"
                       styleClass="custom-file-upload"
                     ></p-fileUpload>
                     <br>  <br>
@@ -1318,7 +1318,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -1360,7 +1360,7 @@
                       url="{{ baseURL }}/methodology-assessment/uploadtest"
                       (onUpload)="onUpload($event)"
                       [multiple]="true"
-                      [maxFileSize]="5000000"
+                      [maxFileSize]="25000000"
                       styleClass="custom-file-upload"
                     ></p-fileUpload><br>  <br>
 
@@ -1461,7 +1461,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -1505,7 +1505,7 @@
                       url="{{ baseURL }}/methodology-assessment/uploadtest"
                       (onUpload)="onUpload($event)"
                       [multiple]="true"
-                      [maxFileSize]="5000000"
+                      [maxFileSize]="25000000"
                       styleClass="custom-file-upload"
                     ></p-fileUpload>
                     <br>  <br>
@@ -1559,7 +1559,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -1602,7 +1602,7 @@
                       url="{{ baseURL }}/methodology-assessment/uploadtest"
                       (onUpload)="onUpload($event)"
                       [multiple]="true"
-                      [maxFileSize]="5000000"
+                      [maxFileSize]="25000000"
                       styleClass="custom-file-upload"
                     ></p-fileUpload><br>  <br>
 

--- a/src/app/Tool/portfolio-track4/portfolio-track4.component.html
+++ b/src/app/Tool/portfolio-track4/portfolio-track4.component.html
@@ -434,7 +434,7 @@
                                 </div>
                                 <div class="row p-2 align-items-center">
                                   <div class="col-2 d-flex align-items-center">
-                                    <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data);" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                    <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data);" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                     </p-fileUpload>
                                   </div>
                                   <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">
@@ -545,7 +545,7 @@
                                   </div>
                                   <div class="row p-2 align-items-center">
                                     <div class="col-2 d-flex align-items-center">
-                                      <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                      <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                       </p-fileUpload>
                                     </div>
                                     <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">
@@ -642,7 +642,7 @@
                                       </div>
                                       <div class="row p-2 align-items-center">
                                         <div class="col-2 d-flex align-items-center">
-                                          <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                          <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                           </p-fileUpload>
                                         </div>
                                         <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">
@@ -715,7 +715,7 @@
                                       </div>
                                       <div class="row p-2 align-items-center">
                                         <div class="col-2 d-flex align-items-center">
-                                          <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="5000000" [auto]="true">
+                                          <p-fileUpload mode="basic" chooseIcon="pi pi-upload" chooseLabel="Upload" name="files" [url]="uploadUrl" (onUpload)="onUpload($event,data)" [multiple]="true" accept="{{acceptedFiles}}" [maxFileSize]="25000000" [auto]="true">
                                           </p-fileUpload>
                                         </div>
                                         <div class="col-2 d-flex align-items-center" *ngIf="data.uploadedDocumentPath">

--- a/src/app/Tool/portfolio-track4/portfolio-track4.component.ts
+++ b/src/app/Tool/portfolio-track4/portfolio-track4.component.ts
@@ -1580,7 +1580,12 @@ export class PortfolioTrack4Component implements OnInit, OnDestroy {
 
   onSelectIntervention(event: any) {
     this.minDate = new Date(event.value.dateOfImplementation)
-    
+
+    if (!this.isEditMode) {
+      this.from_date = new Date(event.value.dateOfImplementation);
+      this.onSelectFromDate(this.from_date);
+    }
+
     this.geographicalArea = this.geographicalAreasCovered.find(item=>{
       if (item.name==this.assessment.climateAction.geographicalAreaCovered){
         return item

--- a/src/app/Tool/portfolio/portfolio.component.html
+++ b/src/app/Tool/portfolio/portfolio.component.html
@@ -184,7 +184,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -247,7 +247,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 
@@ -301,7 +301,7 @@
               url="{{ baseURL }}/methodology-assessment/uploadtest"
               (onUpload)="onUpload($event)"
               [multiple]="true"
-              [maxFileSize]="5000000"
+              [maxFileSize]="25000000"
               styleClass="custom-file-upload"
             ></p-fileUpload>
             <br>  <br>
@@ -338,7 +338,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -390,7 +390,7 @@
               url="{{ baseURL }}/methodology-assessment/uploadtest"
               (onUpload)="onUpload($event)"
               [multiple]="true"
-              [maxFileSize]="5000000"
+              [maxFileSize]="25000000"
               styleClass="custom-file-upload"
             ></p-fileUpload>
             <br>  <br>
@@ -426,7 +426,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 
@@ -506,7 +506,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -573,7 +573,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload><br>  <br>
@@ -635,7 +635,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -678,7 +678,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -738,7 +738,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload>
@@ -780,7 +780,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                   [disabled]="isSubmitted"
                 ></p-fileUpload><br>  <br>
@@ -856,7 +856,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -919,7 +919,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 
@@ -991,7 +991,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload>
                 <br>  <br>
@@ -1061,7 +1061,7 @@
                   url="{{ baseURL }}/methodology-assessment/uploadtest"
                   (onUpload)="onUpload($event)"
                   [multiple]="true"
-                  [maxFileSize]="5000000"
+                  [maxFileSize]="25000000"
                   styleClass="custom-file-upload"
                 ></p-fileUpload><br>  <br>
 

--- a/src/app/climate-action/climate-action/climate-action.component.ts
+++ b/src/app/climate-action/climate-action/climate-action.component.ts
@@ -863,11 +863,9 @@ export class ClimateActionComponent implements OnInit  {
       let obj = new AddPolicySector
       obj.id =this.project.id;
       obj.sector=this.finalSectors;
-     await  this.projectProxy.deletePolicySector(this.project.id).subscribe(async (res)=>{
-      await this.projectProxy.addPolicySector(obj).subscribe((res)=>{});
-     });
-      
-     setTimeout(() => {
+      await this.projectProxy.deletePolicySector(this.project.id).toPromise();
+      await this.projectProxy.addPolicySector(obj).toPromise();
+
       this.sectornames=[]
       for(let x of this.finalSectors){
         this.sectornames.push(x.name)
@@ -893,8 +891,7 @@ export class ClimateActionComponent implements OnInit  {
             sticky: true,
           });
         }
-      )
-    }, 2000);
+      );
 
       
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -104,7 +104,7 @@ export class DashboardComponent implements OnInit {
          } else if (this.isPortfolioTool){
            this.goToPortfolio();
          } else if(this.isAllTool){
-          this.goToAllTool;
+          this.goToAllTool();
          }
       }else{
         this.clickcarbon = true;

--- a/src/app/report/report.component.html
+++ b/src/app/report/report.component.html
@@ -19,13 +19,17 @@
         <div class="row mb-3"></div>
         <h6 class="mt-4" style="color: #1a4f7b">Reports</h6>
         <div class="row">
-            <div _ngcontent-mil-c27="" style="padding: 10px; cursor: pointer;" class="col-md-4 col-xs-6 ng-star-inserted" *ngFor="let r of pdfFiles">
-                <div _ngcontent-mil-c27="" class="row  d-flex justify-content-center">
-                    <img (click)="view(r.savedLocation)" _ngcontent-mil-c27="" src="./assets/images/pdf.webp" style="display: block; min-width:120px;max-width: 120px;">
+            <div style="padding: 10px; cursor: pointer;" class="col-md-4 col-xs-6" *ngFor="let r of pdfFiles">
+                <div class="row  d-flex justify-content-center">
+                    <img (click)="view(r.savedLocation)" src="./assets/images/pdf.webp" style="display: block; min-width:120px;max-width: 120px;">
                 </div>
-                <div _ngcontent-mil-c27="" class="row d-flex justify-content-center">
-                    <span  class="row d-flex justify-content-center" (click)="view(r.savedLocation)">{{r.reportName}}</span>                
+                <div class="row d-flex justify-content-center">
+                    <span class="row d-flex justify-content-center" (click)="view(r.savedLocation)">{{r.reportName}}</span>
+                </div>
+                <div class="row d-flex justify-content-center mt-1">
+                    <button pButton type="button" icon="pi pi-trash" class="p-button-danger p-button-text p-button-sm" pTooltip="Delete report" (click)="deleteReport(r)"></button>
                 </div>
             </div>
         </div>
     </div>
+<p-confirmDialog></p-confirmDialog>

--- a/src/app/report/report.component.ts
+++ b/src/app/report/report.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { GuidanceVideoComponent } from 'app/guidance-video/guidance-video.component';
 import { MasterDataService } from 'app/shared/master-data.service';
 import { environment } from 'environments/environment';
-import { MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { Assessment, ClimateAction, CreateReportDto, MethodologyAssessmentControllerServiceProxy, ProjectControllerServiceProxy, ReportControllerServiceProxy } from 'shared/service-proxies/service-proxies';
 
@@ -42,6 +42,7 @@ export class ReportComponent implements OnInit {
     private masterDataService: MasterDataService,
     private messageService: MessageService,
     protected dialogService: DialogService,
+    private confirmationService: ConfirmationService,
   ) { }
 
   async ngOnInit(): Promise<void> {
@@ -172,5 +173,34 @@ export class ReportComponent implements OnInit {
     return returnType
   }
 
+  deleteReport(report: any) {
+    this.confirmationService.confirm({
+      message: `Are you sure you want to delete "${report.reportName}"?`,
+      header: 'Delete Confirmation',
+      acceptLabel: 'Delete',
+      rejectLabel: 'Cancel',
+      accept: () => {
+        this.reportControllerServiceProxy.remove(report.id.toString()).subscribe(
+          () => {
+            this.messageService.add({
+              severity: 'success',
+              summary: 'Success',
+              detail: 'Report deleted successfully',
+              closable: true,
+            });
+            this.filterReportData();
+          },
+          (err) => {
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Error',
+              detail: 'Failed to delete report',
+              closable: true,
+            });
+          }
+        );
+      }
+    });
+  }
 
 }


### PR DESCRIPTION
TC toolkit bugs across backend and frontend
- Fix SDG GROUP BY error in sdgSumCalculate (investor-tool.service)
- Add null guard to TokenDetails to prevent 500 on expired JWT
- Fix multi-user data loss: add await to policy sector save, remove setTimeout race condition
- Fix draft save overwriting assessment dates (use targeted UPDATE)
- Add Save as Draft to Carbon Market initial assessment form
- Auto-populate from_date from intervention dateOfImplementation
- Increase file upload limit from 5MB to 25MB
- Implement report soft-delete with frontend delete button
- Add error handling/audit logging to generateComparisonReport
- Fix goToAllTool missing parentheses in dashboard
- Standardize report PDF dates to DD/MM/YYYY via moment